### PR TITLE
Count even subpackages

### DIFF
--- a/fedoracommunity/client/templates/search_results.html
+++ b/fedoracommunity/client/templates/search_results.html
@@ -6,7 +6,7 @@
     <div class="grid_12 suffix_12" id="search-notes">
       <div class="grid-controls" if="filters.search!=''">
         <div class="message template text-xs-center text-muted py-1" id="info_display">
-           {{ packages | count }} results
+           {{ packages_count }} results
         </div>
       </div>
     </div>

--- a/fedoracommunity/server/main/views.py
+++ b/fedoracommunity/server/main/views.py
@@ -6,6 +6,7 @@ from flask import render_template, Blueprint
 
 from ..updates import get_updates
 from ..builds import get_builds
+from ..packages import count_packages
 from ..bugs import get_bugs
 from ..changelogs import get_changelogs
 from ...server import cache
@@ -43,7 +44,8 @@ def packages_search(package_name=None):
     ]
 
     return render_template("search_results.html",
-                           packages=packages)
+                           packages=packages,
+                           packages_count=count_packages(packages))
 
 
 @main_blueprint.route("/packages/")

--- a/fedoracommunity/server/packages.py
+++ b/fedoracommunity/server/packages.py
@@ -1,0 +1,3 @@
+def count_packages(packages):
+    subpackages = sum([len(package.subpackages) for package in packages])
+    return len(packages) + subpackages


### PR DESCRIPTION
Fixing an issue from previous PR

> I guess the number of found results should count even subpackages not only packages, right?

It does now.