### PR TITLE
Validate search form input

### DIFF
--- a/fedora-packages.spec
+++ b/fedora-packages.spec
@@ -37,6 +37,12 @@ Requires:       xstatic-bootstrap-scss-common
 Requires:       xstatic-datatables-common
 Requires:       xstatic-jquery-ui-common
 Requires:       xstatic-patternfly-common
+
+# flask-wtf-decorators is in the package review process
+# https://copr.fedorainfracloud.org/coprs/frostyx/flask-wtf-decorators/
+# https://bugzilla.redhat.com/show_bug.cgi?id=1853510
+Requires:       flask-wtf-decorators
+
 # web service
 Recommends:     httpd
 Recommends:     python3-mod_wsgi

--- a/fedoracommunity/server/config.py
+++ b/fedoracommunity/server/config.py
@@ -42,4 +42,3 @@ class ProductionConfig(BaseConfig):
         "DATABASE_URL",
         "sqlite:///{0}".format(os.path.join(basedir, "prod.db")),
     )
-    WTF_CSRF_ENABLED = True

--- a/fedoracommunity/server/main/forms.py
+++ b/fedoracommunity/server/main/forms.py
@@ -1,0 +1,14 @@
+from flask_wtf import FlaskForm
+from wtforms import StringField
+from wtforms.validators import DataRequired, Regexp
+from flask_wtf_decorators import FormValidator
+
+
+validator = FormValidator()
+
+
+class Search(FlaskForm):
+    package_name = StringField("Package name", validators=[
+        DataRequired(message="Package name is required"),
+        Regexp("^[a-zA-Z0-9-_]+$", message="Package names contain only alphanumeric characters and separators"),
+    ])


### PR DESCRIPTION
It was pointed out on a mailing list that if we put special characters
such as *, /, +, etc in the search form, it will result into _weird_
behavior (because those are passed to xapian search string). Let's
just validate the input.

The validation could be a bit _simpler_ but for a long time I was
interested in trying `flask-wtf-decorators` package in my projects,
so I would like to take this opportunity to use it and figure out
potential issues with it. This project is quite small and won't
have a lot of form validation in it, so throwing away this
dependency will allways be a matter of minutes.

At this moment, the `flask-wtf-decorators` package is going through
a Fedora review, so please temporarily use a Copr repo

https://bugzilla.redhat.com/show_bug.cgi?id=1853510
https://copr.fedorainfracloud.org/coprs/frostyx/flask-wtf-decorators/

I stumbled upon the concept of validating inputs before the
code even jumps into a view (in the Flask terminology) way back
when I was working with Laravel 4. The code was much clearer because
views could simply focus on doing their thing, instead of repeating
the same conditions over and over again. It might be cool to use it
in a larger projects such as Copr but let's just practise here first.

If the idea turns out to be good but this particular implementation
isn't very pragmatic, then we can try an alternative called
`flask-validates`.

https://github.com/tjpnz/flask-validates